### PR TITLE
Add [@ocaml.principal] and [@ocaml.noprincipal] attributes, and use in oo.mli

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -338,6 +338,15 @@ let clflags_attribute_with_int_payload attr ~name clflags_ref =
     | None -> ()
   end
 
+let principal_attribute attr =
+  clflags_attribute_without_payload attr
+    ~name:"principal" Clflags.principal
+
+let noprincipal_attribute attr =
+  clflags_attribute_without_payload' attr
+    ~name:"noprincipal"
+    ~f:(fun () -> Clflags.principal := false)
+
 let nolabels_attribute attr =
   clflags_attribute_without_payload attr
     ~name:"nolabels" Clflags.classic
@@ -377,10 +386,14 @@ let afl_inst_ratio_attribute attr =
 
 let parse_standard_interface_attributes attr =
   warning_attribute attr;
+  principal_attribute attr;
+  noprincipal_attribute attr;
   nolabels_attribute attr
 
 let parse_standard_implementation_attributes attr =
   warning_attribute attr;
+  principal_attribute attr;
+  noprincipal_attribute attr;
   nolabels_attribute attr;
   inline_attribute attr;
   afl_inst_ratio_attribute attr;

--- a/stdlib/oo.mli
+++ b/stdlib/oo.mli
@@ -18,6 +18,8 @@ open! Stdlib
 
 (** Operations on objects *)
 
+[@@@ocaml.noprincipal] (* preserve structure sharing in copy (PR#9767) *)
+
 val copy : (< .. > as 'a) -> 'a
 (** [Oo.copy o] returns a copy of object [o], that is a fresh
    object with the same methods and instance variables as [o]. *)


### PR DESCRIPTION
In f533fadb56a6421a341c9e33eb826365cf888020, the stdlib's Compflags script was removed, and custom per-file flags were instead specified using attributes in the source file. However, the `-no-principal` flag on `oo.mli` was dropped, leading to a test failure in `typing-objects/Exemples.ml`.

This patch restores `-no-principal` for this file, by adding it (and `-principal`) as new attributes.